### PR TITLE
Docker secrets via script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,67 +166,66 @@ RUN ./install_bioc.r \
 
 ### Install R packages from GitHub ###
 
-# To install R packages from GitHub without getting rate limited
-ARG GITHUB_PAT=""
+COPY scripts/install_github.r .
 
 # maftools for proof of concept in create-subset-files
-RUN R -e "remotes::install_github('PoisonAlien/maftools', ref = '9719868262f946e0b8eb2e7ec2510ee18c6cafa3')"
+RUN --mount=type=secret,id=gh_pat ./install_github.r 'PoisonAlien/maftools' --ref '9719868262f946e0b8eb2e7ec2510ee18c6cafa3' --pat_file /run/secrets/gh_pat
 
 # TCGAbiolinks for TMB compare analysis
-RUN R -e "remotes::install_github('RDocTaskForce/parsetools', ref = '1e682a9f4c5c7192d22e8985ce7723c09e98d62b', dependencies = TRUE)" \
-    && R -e "remotes::install_github('RDocTaskForce/testextra', ref = '4e5dfac8853c08d5c2a8790a0a1f8165f293b4be', dependencies = TRUE)" \
-    && R -e "remotes::install_github('halpo/purrrogress', ref = '54f2130477f161896e7b271ed3ea828c7e4ccb1c', dependencies = TRUE)" \
+RUN --mount=type=secret,id=gh_pat ./install_github.r 'RDocTaskForce/parsetools' --ref '1e682a9f4c5c7192d22e8985ce7723c09e98d62b' --pat_file /run/secrets/gh_pat \
+    && ./install_github.r 'RDocTaskForce/testextra' --ref '4e5dfac8853c08d5c2a8790a0a1f8165f293b4be' --pat_file /run/secrets/gh_pat \
+    && ./install_github.r 'halpo/purrrogress' --ref '54f2130477f161896e7b271ed3ea828c7e4ccb1c' --pat_file /run/secrets/gh_pat \
     && ./install_bioc.r TCGAbiolinks
 
 # package required for immune deconvolution
-RUN R -e "remotes::install_github('icbi-lab/immunedeconv', ref = '493bcaa9e1f73554ac2d25aff6e6a7925b0ea7a6', dependencies = TRUE)"
+RUN --mount=type=secret,id=gh_pat ./install_github.r 'icbi-lab/immunedeconv' --ref '493bcaa9e1f73554ac2d25aff6e6a7925b0ea7a6'--pat_file /run/secrets/gh_pat
 
-RUN R -e "remotes::install_github('const-ae/ggupset', ref = '7a33263cc5fafdd72a5bfcbebe5185fafe050c73', dependencies = TRUE)"
+RUN --mount=type=secret,id=gh_pat ./install_github.r 'const-ae/ggupset' --ref '7a33263cc5fafdd72a5bfcbebe5185fafe050c73' --pat_file /run/secrets/gh_pat
 
 # This is needed to create the interactive pie chart
-RUN R -e "remotes::install_github('timelyportfolio/sunburstR', ref = 'd40d7ed71ee87ca4fbb9cb8b7cf1e198a23605a9', dependencies = TRUE)"
+RUN --mount=type=secret,id=gh_pat ./install_github.r 'timelyportfolio/sunburstR' --ref 'd40d7ed71ee87ca4fbb9cb8b7cf1e198a23605a9' --pat_file /run/secrets/gh_pat
 
 # This is needed to create the interactive treemap
-RUN R -e "remotes::install_github('timelyportfolio/d3treeR', ref = '0eaba7f1c6438e977f8a5c082f1474408ac1fd80', dependencies = TRUE)"
+RUN --mount=type=secret,id=gh_pat ./install_github.r 'timelyportfolio/d3treeR' --ref '0eaba7f1c6438e977f8a5c082f1474408ac1fd80' --pat_file /run/secrets/gh_pat
 
 # Need this package to make plots colorblind friendly
-RUN R -e "remotes::install_github('clauswilke/colorblindr', ref = '1ac3d4d62dad047b68bb66c06cee927a4517d678', dependencies = TRUE)"
+RUN --mount=type=secret,id=gh_pat ./install_github.r  'clauswilke/colorblindr' --ref '1ac3d4d62dad047b68bb66c06cee927a4517d678' --pat_file /run/secrets/gh_pat
 
 # remote package EXTEND needed for telomerase-activity-prediction analysis
-RUN R -e "remotes::install_github('NNoureen/EXTEND', ref = '467c2724e1324ef05ad9260c3079e5b0b0366420', dependencies = TRUE)"
+RUN --mount=type=secret,id=gh_pat ./install_github.r  'NNoureen/EXTEND' --ref '467c2724e1324ef05ad9260c3079e5b0b0366420' --pat_file /run/secrets/gh_pat
 
 # package required for shatterseek
-RUN R -e "withr::with_envvar(c(R_REMOTES_NO_ERRORS_FROM_WARNINGS='true'), remotes::install_github('parklab/ShatterSeek', ref = '83ab3effaf9589cc391ecc2ac45a6eaf578b5046', dependencies = TRUE))"
+RUN --mount=type=secret,id=gh_pat R_REMOTES_NO_ERRORS_FROM_WARNINGS='true' ./install_github.r 'parklab/ShatterSeek' --ref '83ab3effaf9589cc391ecc2ac45a6eaf578b5046' --pat_file /run/secrets/gh_pat
 
 # Patchwork for plot compositions
-RUN R -e "remotes::install_github('thomasp85/patchwork', ref = 'c67c6603ba59dd46899f17197f9858bc5672e9f4')"
+RUN --mount=type=secret,id=gh_pat ./install_github.r  'thomasp85/patchwork' --ref 'c67c6603ba59dd46899f17197f9858bc5672e9f4' --pat_file /run/secrets/gh_pat
 
 # This is required for creating a treemap of the broad histology and integrated diagnoses
-RUN R -e "remotes::install_github('wilkox/treemapify', ref = 'e70adf727f4d13223de8146458db9bef97f872cb', dependencies = TRUE)"
+RUN --mount=type=secret,id=gh_pat ./install_github.r  'wilkox/treemapify' --ref 'e70adf727f4d13223de8146458db9bef97f872cb' --pat_file /run/secrets/gh_pat
 
 # Need this specific version of circlize so it has hg38
-RUN R -e "remotes::install_github('jokergoo/circlize', ref = 'b7d86409d7f893e881980b705ba1dbc758df847d', dependencies = TRUE)"
+RUN --mount=type=secret,id=gh_pat ./install_github.r  'jokergoo/circlize' --ref 'b7d86409d7f893e881980b705ba1dbc758df847d' --pat_file /run/secrets/gh_pat
 
 # More recent version of sva required for molecular subtyping MB
-RUN R -e "remotes::install_github('jtleek/sva-devel@123be9b2b9fd7c7cd495fab7d7d901767964ce9e', dependencies = FALSE, upgrade = FALSE)"
+RUN --mount=type=secret,id=gh_pat ./install_github.r  'jtleek/sva-devel@123be9b2b9fd7c7cd495fab7d7d901767964ce9e' --no_deps --pat_file /run/secrets/gh_pat
 
 # To install sigfit, we need a more recent version of rstantools than we can obtain via the MRAN snapshot route
 # We're using the ref for the most recent release on GitHub (2.0.0)
-RUN R -e "remotes::install_github('stan-dev/rstantools', ref = 'd43bf9fb6120d40a60e708853e4b80cdb4689d19', dependencies = TRUE)"
+RUN --mount=type=secret,id=gh_pat ./install_github.r  'stan-dev/rstantools' --ref 'd43bf9fb6120d40a60e708853e4b80cdb4689d19' --pat_file /run/secrets/gh_pat
 
 # Build arguments are according to the sigfit instructions
 RUN R -e "remotes::install_github('kgori/sigfit', ref = '209776ee1d2193ad4b682b2e2472f848bd7c67a6', build_vignettes = TRUE, build_opts = c('--no-resave-data', '--no-manual'), dependencies = TRUE)"
 
-RUN R -e "remotes::install_github('d3b-center/annoFuse',ref = 'c6a2111b5949ca2aae3853f7f34de3d0db4ffa33', dependencies = TRUE)"
+RUN --mount=type=secret,id=gh_pat ./install_github.r  'd3b-center/annoFuse' --ref 'c6a2111b5949ca2aae3853f7f34de3d0db4ffa33' --pat_file /run/secrets/gh_pat
 
 # CNS signatures can be obtained from signature.tools.lib
-RUN R -e "remotes::install_github('Nik-Zainal-Group/signature.tools.lib', ref = '73e899c9090a215a76a307480bda76c241a4a489')"
+RUN --mount=type=secret,id=gh_pat ./install_github.r  'Nik-Zainal-Group/signature.tools.lib' --ref '73e899c9090a215a76a307480bda76c241a4a489' --pat_file /run/secrets/gh_pat
 
 # Patterned geoms
-RUN R -e "remotes::install_github('coolbutuseless/ggpattern', ref = '390e13fead028ba240eae9293a5ef422df02bc8e')"
+RUN --mount=type=secret,id=gh_pat ./install_github.r  'coolbutuseless/ggpattern' --ref '390e13fead028ba240eae9293a5ef422df02bc8e' --pat_file /run/secrets/gh_pat
 
 # Molecular subtyping MB
-RUN R -e "remotes::install_github('d3b-center/medullo-classifier-package', ref = 'e3d12f64e2e4e00f5ea884f3353eb8c4b612abe8', dependencies = TRUE, upgrade = FALSE)" \
+RUN --mount=type=secret,id=gh_pat ./install_github.r  'd3b-center/medullo-classifier-package' --ref 'e3d12f64e2e4e00f5ea884f3353eb8c4b612abe8' --pat_file /run/secrets/gh_pat \
     && Rscript -e "library(medulloPackage)"
 
 

--- a/scripts/install_github.r
+++ b/scripts/install_github.r
@@ -1,0 +1,37 @@
+#!/usr/bin/env Rscript
+#
+# Installs R packages from github, optionally using a PAT stored in a file
+#
+# Josh Shapiro for CCDL
+#
+# Install packages from github using remotes::install_github()
+# Allows specification of a file containing a GitHub PAT to avoid rate limiting.
+
+
+library(docopt)
+
+doc <- "Usage: 
+  install_github.r <repository> [options]
+
+Options:
+  -h --help           show this help text
+  --ref <reference>   optional commit reference
+  --pat_file <file>   a file containing a GitHub Personal Access Token
+  --no_deps           don't install dependencies
+"
+
+opts <- docopt(doc)
+
+if(is.null(opts$pat_file)){
+  pat <- NULL
+}else{
+  pat <- scan(opts$pat_file, what = "character", n = 1)
+}
+
+# remotes::install_github(repo = opts$repository,
+#                         ref = opts$ref,
+#                         dependencies = !opts$no_deps,
+#                         auth_token = pat,
+#                         dependencies = TRUE,
+#                         upgrade = FALSE)
+print(opts)

--- a/scripts/install_github.r
+++ b/scripts/install_github.r
@@ -28,10 +28,8 @@ if(is.null(opts$pat_file)){
   pat <- scan(opts$pat_file, what = "character", n = 1)
 }
 
-# remotes::install_github(repo = opts$repository,
-#                         ref = opts$ref,
-#                         dependencies = !opts$no_deps,
-#                         auth_token = pat,
-#                         dependencies = TRUE,
-#                         upgrade = FALSE)
-print(opts)
+remotes::install_github(repo = opts$repository,
+                        ref = opts$ref,
+                        dependencies = !opts$no_deps,
+                        auth_token = pat,
+                        upgrade = FALSE)

--- a/scripts/run_in_ci.sh
+++ b/scripts/run_in_ci.sh
@@ -15,7 +15,10 @@ echo "Rebuilding the Docker image."
 finished=1
 attempts=0
 
+# Use BuildKit
 export DOCKER_BUILDKIT=1
+# Simpler output for progress tracking
+export BUILDKIT_PROGRESS=plain
 
 while [ $finished != 0 ] && [ $attempts -lt 3 ]; do
     if [ $attempts -gt 0 ]; then

--- a/scripts/run_in_ci.sh
+++ b/scripts/run_in_ci.sh
@@ -14,11 +14,14 @@ cd ..
 echo "Rebuilding the Docker image."
 finished=1
 attempts=0
+
+export DOCKER_BUILDKIT=1
+
 while [ $finished != 0 ] && [ $attempts -lt 3 ]; do
     if [ $attempts -gt 0 ]; then
         echo "Failed to build Docker image, trying again."
     fi
-    DOCKER_BUILDKIT=1
+    
     docker build \
            --secret id=gh_pat,env=GH_PAT \
            --tag "open-pbta" \

--- a/scripts/run_in_ci.sh
+++ b/scripts/run_in_ci.sh
@@ -20,7 +20,7 @@ while [ $finished != 0 ] && [ $attempts -lt 3 ]; do
     fi
 
     docker build \
-           --secret id=GITHUB_PAT,env=GH_PAT \
+           --secret id=gh_pat,env=GH_PAT \
            --tag "open-pbta" \
            --file "Dockerfile" .
     finished=$?

--- a/scripts/run_in_ci.sh
+++ b/scripts/run_in_ci.sh
@@ -18,7 +18,7 @@ while [ $finished != 0 ] && [ $attempts -lt 3 ]; do
     if [ $attempts -gt 0 ]; then
         echo "Failed to build Docker image, trying again."
     fi
-
+    DOCKER_BUILDKIT=1
     docker build \
            --secret id=gh_pat,env=GH_PAT \
            --tag "open-pbta" \


### PR DESCRIPTION
Here I am adding a very basic r script that simply calls `remotes::install_github()` after potentially reading a PAT from a file. 

I updated all but one of the github package installations  to use this, but I didn't want to make the script as complicated as it seemed to require to accommodate the extra options for the `sigfit` package. I'd say it isn't pretty, but the docker build does seem to work in my local testing, both failing with a bad PAT and working when I provide one.